### PR TITLE
Run AC pulse generation in a FreeRTOS task to stop reboots

### DIFF
--- a/devices/sonoff-nsp.h
+++ b/devices/sonoff-nsp.h
@@ -1,9 +1,21 @@
 #include "esphome.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
 
+// The Dometic A/C requires a continuous pulse train on the control line — it
+// stops the moment the signal stops. Running that train inside ESPHome's
+// loop() blocks the main task for ~250 ms per pattern, which starves WiFi /
+// MQTT and eventually trips the watchdog (silent reboots every few minutes).
+//
+// Fix: emit the pattern from a dedicated FreeRTOS task. The task busy-loops
+// the pulses, but FreeRTOS preempts at every tick (1 ms), and a vTaskDelay(1)
+// between iterations hands the scheduler back to ESPHome / WiFi / MQTT. The
+// Dometic still sees an effectively continuous stream.
 class AC_Control : public Component {
   public:
     int AC_signal_genPIN;
-    int AC_command;
+    volatile int AC_command = 0;   // shared with task; volatile, single 32-bit aligned int is atomic on ESP32
+
     AC_Control(int pin, esphome::template_::TemplateNumber *&_command)
     {
       AC_signal_genPIN = pin;
@@ -12,30 +24,42 @@ class AC_Control : public Component {
 
     void setup() override {
       pinMode(AC_signal_genPIN, OUTPUT);
+      // Pin to APP_CPU (core 1) so we don't disturb WiFi/BT on PRO_CPU (core 0).
+      // Same priority as the Arduino loop task → FreeRTOS round-robin time-slices.
+      xTaskCreatePinnedToCore(
+        &AC_Control::task_trampoline,
+        "ac_ctrl",
+        4096,
+        this,
+        1,
+        nullptr,
+        1
+      );
     }
 
     void loop() override {
-      if (AC_command==0) {
-        AC_off();
-//        ESP_LOGD("custom", "Turn off AC. Command = %d, PIN = %d", AC_command, AC_signal_genPIN);
-      }
-      if (AC_command==1) {
-        AC_fan_low();
-//        ESP_LOGD("custom", "Turn on low fan");
-      }
-      if (AC_command==2) {
-        AC_fan_high();
-//        ESP_LOGD("custom", "Turn on high fan");
-      }
-      if (AC_command==3) {
-        AC_cool_low();
-//        ESP_LOGD("custom", "Turn on AC, low fan speed");
-      }
-      if (AC_command==4) {
-        AC_cool_high();
-//        ESP_LOGD("custom", "Turn on AC, high fan speed");
+      // Intentionally empty — pulse generation runs in the FreeRTOS task above.
+    }
+
+  private:
+    static void task_trampoline(void *arg) {
+      static_cast<AC_Control*>(arg)->task_run();
+    }
+
+    void task_run() {
+      for (;;) {
+        switch (AC_command) {
+          case 0: AC_off();       break;
+          case 1: AC_fan_low();   break;
+          case 2: AC_fan_high();  break;
+          case 3: AC_cool_low();  break;
+          case 4: AC_cool_high(); break;
+        }
+        vTaskDelay(1);  // yield ~1 tick so other tasks always run
       }
     }
+
+  public:
 
     void AC_off() {
       // Add instructions


### PR DESCRIPTION
## Summary
- Fixes silent reboots of the G6 thermostat every few minutes whenever an AC is on.
- Moves the Dometic pulse-train generation in `AC_Control` from ESPHome's `loop()` into a dedicated FreeRTOS task so it no longer blocks the main task.

## Root cause
`AC_Control::loop()` calls `AC_fan_low()` / `AC_cool_low()` etc. on every ESPHome tick. Each of those is a long sequence of `digitalWrite` + `delayMicroseconds` calls totaling ~250 ms of busy-waiting. With two `AC_Control` instances (bedroom + living), the main task was blocked for roughly half a second every iteration.

The MQTT debug log showed this continuously:
```
[W][component:237]: Component custom_component took a long time for an operation (254-261 ms).
[W][component:238]: Components should block for at most 30 ms.
```
…followed every few minutes by a clean `MQTT Connected!` / `setup() finished successfully!` with no crash dump — the textbook signature of a watchdog reset caused by a blocked main loop.

## Why we can't fire only on change
The Dometic stops the moment the signal stops, so the pattern genuinely has to be re-emitted continuously.

## Approach
- Spawn one FreeRTOS task per `AC_Control` instance, pinned to APP_CPU (core 1) at the same priority as the Arduino loop task. PRO_CPU (core 0) is left alone so WiFi/BT aren't disturbed.
- The task tight-loops the pulse pattern (Dometic still sees a continuous stream), but a `vTaskDelay(1)` between iterations gives the scheduler a tick — ESPHome, MQTT and WiFi round-robin back in. FreeRTOS also preempts at the 1 ms tick during `delayMicroseconds`, so even mid-pattern other tasks get CPU.
- ESPHome's `loop()` becomes empty — no more "Component took a long time" warnings.
- `AC_command` is `volatile` and a single 32-bit aligned int, so writes from the ESPHome callback are atomic w.r.t. the task; no mutex needed.

## Test plan
- [ ] Flash to G6 thermostat and confirm no `Component custom_component took a long time` warnings appear in `g6-thermostat/debug`.
- [ ] Leave both ACs on (mode 3 / cool_low) for >30 minutes and confirm there are no reboots (no repeated `MQTT Connected!` / `setup() finished successfully!` lines).
- [ ] Verify both ACs still respond to commands 0–4 from the Nextion UI and from Home Assistant.
- [ ] Confirm WiFi RSSI and MQTT keepalive remain steady while ACs are running.
- [ ] Sanity-check stack high-water mark for the `ac_ctrl` task if reboots reappear (4096 bytes should be plenty for `digitalWrite` + `delayMicroseconds`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)